### PR TITLE
feat: add runtime metrics

### DIFF
--- a/api.go
+++ b/api.go
@@ -56,6 +56,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 }
 
 type Metrics struct {
+	ID          string `json:"id"`
 	Domain      string `json:"domain"`
 	Image       string `json:"image"`
 	CPUUtil     int    `json:"cpu_util"`
@@ -125,6 +126,7 @@ func handleMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	metrics := Metrics{
+		ID:      externalConfig.Metadata.ID,
 		Domain:  externalConfig.Metadata.Domain,
 		Image:   externalConfig.Metadata.Image,
 		CPUType: externalConfig.Metadata.CPU,

--- a/api.go
+++ b/api.go
@@ -8,6 +8,9 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/mackerelio/go-osstat/cpu"
+	"github.com/mackerelio/go-osstat/memory"
 	log "github.com/sirupsen/logrus"
 	"github.com/tinfoilsh/stransport/identity"
 	ehbpProtocol "github.com/tinfoilsh/stransport/protocol"
@@ -50,6 +53,117 @@ func corsMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+type Metrics struct {
+	Domain      string `json:"domain"`
+	Image       string `json:"image"`
+	CPUUtil     int    `json:"cpu_util"`
+	GPUUtil     int    `json:"gpu_util,omitempty"`
+	CPUMemUtil  int    `json:"cpu_mem_util"`
+	GPUMemUtil  int    `json:"gpu_mem_util,omitempty"`
+	CPUMemTotal int    `json:"cpu_mem_total"`
+	GPUMemTotal int    `json:"gpu_mem_total,omitempty"`
+	CPUType     string `json:"cpu_type"`
+	GPUType     string `json:"gpu_type,omitempty"`
+}
+
+func gpuMetrics() (int, int, int, error) {
+	ret := nvml.Init()
+	if ret != nvml.SUCCESS {
+		return 0, 0, 0, fmt.Errorf("Unable to initialize NVML: %v", nvml.ErrorString(ret))
+	}
+	defer nvml.Shutdown()
+
+	var totalMem, usedMem, totalUtil int
+
+	count, ret := nvml.DeviceGetCount()
+	if ret != nvml.SUCCESS {
+		return 0, 0, 0, fmt.Errorf("Unable to get device count: %v", nvml.ErrorString(ret))
+	}
+	for i := 0; i < count; i++ {
+		device, ret := nvml.DeviceGetHandleByIndex(i)
+		if ret != nvml.SUCCESS {
+			return 0, 0, 0, fmt.Errorf("Unable to get device at index %d: %v", i, nvml.ErrorString(ret))
+		}
+
+		info, ret := nvml.DeviceGetMemoryInfo_v2(device)
+		if ret != nvml.SUCCESS {
+			return 0, 0, 0, fmt.Errorf("Unable to get memory info for device at index %d: %v", i, nvml.ErrorString(ret))
+		}
+		totalMem += int(info.Total / 1024 / 1024 / 1024) // to GB
+		usedMem += int(info.Used / 1024 / 1024 / 1024)
+
+		// Get GPU utilization rates
+		rates, ret := nvml.DeviceGetUtilizationRates(device)
+		if ret != nvml.SUCCESS {
+			return 0, 0, 0, fmt.Errorf("Unable to get utilization rates for device at index %d: %v", i, nvml.ErrorString(ret))
+		} else {
+			totalUtil += int(rates.Gpu)
+		}
+	}
+
+	// Calculate average utilization across all GPUs
+	avgUtil := 0
+	if count > 0 && totalUtil > 0 {
+		avgUtil = totalUtil / count
+	}
+
+	return totalMem, usedMem, avgUtil, nil
+}
+
+func handleMetrics(w http.ResponseWriter, r *http.Request) {
+	if externalConfig.MetricsAPIKey != "" {
+		apiKey := strings.TrimPrefix(
+			r.Header.Get("Authorization"),
+			"Bearer ",
+		)
+		if apiKey != externalConfig.MetricsAPIKey {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	metrics := Metrics{
+		Domain:  externalConfig.Metadata.Domain,
+		Image:   externalConfig.Metadata.Image,
+		CPUType: externalConfig.Metadata.CPU,
+	}
+
+	memory, err := memory.Get()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	metrics.CPUMemTotal = int(memory.Total / 1024 / 1024 / 1024) // to GB
+	metrics.CPUMemUtil = int(memory.Used / 1024 / 1024 / 1024)
+
+	cpuStats, err := cpu.Get()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	busy := cpuStats.User + cpuStats.System + cpuStats.Nice
+	total := busy + cpuStats.Idle
+	metrics.CPUUtil = int(float64(busy) / float64(total) * 100)
+
+	// Set GPU metrics if available
+	if externalConfig.Metadata.GPU != "" && externalConfig.Metadata.GPU != "none" {
+		totalMem, usedMem, gpuUtil, err := gpuMetrics()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		metrics.GPUMemTotal = totalMem
+		metrics.GPUMemUtil = usedMem
+		metrics.GPUUtil = gpuUtil
+		metrics.GPUType = externalConfig.Metadata.GPU
+	}
+
+	if err := json.NewEncoder(w).Encode(metrics); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 }
 
 func newMux(
@@ -118,6 +232,8 @@ func newMux(
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(att)
 	})))
+
+	mux.HandleFunc("/.well-known/tinfoil-metrics", handleMetrics)
 
 	mux.HandleFunc(ehbpProtocol.KeysPath, ehbpIdentity.ConfigHandler)
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tinfoilsh/tfshim
 go 1.25.0
 
 require (
+	github.com/NVIDIA/go-nvml v0.13.0-1
 	github.com/creasty/defaults v1.8.0
 	github.com/go-acme/lego/v4 v4.23.1
 	github.com/google/go-sev-guest v0.12.1
@@ -32,6 +33,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/letsencrypt/boulder v0.20250902.0 // indirect
+	github.com/mackerelio/go-osstat v0.2.6 // indirect
 	github.com/miekg/dns v1.1.64 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/NVIDIA/go-nvml v0.13.0-1 h1:OLX8Jq3dONuPOQPC7rndB6+iDmDakw0XTYgzMxObkEw=
+github.com/NVIDIA/go-nvml v0.13.0-1/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -58,6 +60,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/letsencrypt/boulder v0.20250902.0 h1:pA8S/6i0LtzBHPEU/a7SS5CBbflz90s7moOSmVClIgw=
 github.com/letsencrypt/boulder v0.20250902.0/go.mod h1:62YoxTTNWjfDr0pV7ZPhyV4j/0/OT1QEf/sWwul/XqE=
+github.com/mackerelio/go-osstat v0.2.6 h1:gs4U8BZeS1tjrL08tt5VUliVvSWP26Ai2Ob8Lr7f2i0=
+github.com/mackerelio/go-osstat v0.2.6/go.mod h1:lRy8V9ZuHpuRVZh+vyTkODeDPl3/d5MgXHtLSaqG8bA=
 github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
 github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/miekg/dns v1.1.64 h1:wuZgD9wwCE6XMT05UU/mlSko71eRSXEAm2EbjQXLKnQ=

--- a/main.go
+++ b/main.go
@@ -59,6 +59,13 @@ var externalConfig struct {
 	Domain              string `yaml:"domain"`
 	CloudflareDNSToken  string `yaml:"cloudflare-dns-token"`
 	CloudflareZoneToken string `yaml:"cloudflare-zone-token"`
+	MetricsAPIKey       string `yaml:"metrics-api-key"`
+	Metadata            struct {
+		Domain string `yaml:"domain"`
+		Image  string `yaml:"image"`
+		CPU    string `yaml:"cpu"`
+		GPU    string `yaml:"gpu"`
+	} `yaml:"metadata"`
 }
 
 var (

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ var externalConfig struct {
 	CloudflareZoneToken string `yaml:"cloudflare-zone-token"`
 	MetricsAPIKey       string `yaml:"metrics-api-key"`
 	Metadata            struct {
+		ID     string `yaml:"id"`
 		Domain string `yaml:"domain"`
 		Image  string `yaml:"image"`
 		CPU    string `yaml:"cpu"`


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a runtime metrics endpoint to expose CPU/GPU utilization and memory in JSON, with optional Bearer auth. This helps monitor node health and capacity.

- **New Features**
  - New endpoint: GET /.well-known/tinfoil-metrics
  - Returns: domain, image, CPU/GPU type; CPU util%; CPU mem total/used (GB); GPU util% and mem total/used (GB) when GPU is present
  - GPU stats use NVIDIA NVML and average across GPUs
  - Optional API key auth via Authorization: Bearer <token>

- **Migration**
  - Optional: add metrics-api-key to config to require auth
  - Add metadata.domain, metadata.image, metadata.cpu, metadata.gpu to config for enriched output
  - For GPU metrics, ensure NVIDIA drivers/NVML are available on the host

<!-- End of auto-generated description by cubic. -->

