### PR TITLE
feat: pass through controlplane error msgs

### DIFF
--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -15,6 +16,7 @@ import (
 	"github.com/tinfoilsh/stransport/identity"
 	ehbpProtocol "github.com/tinfoilsh/stransport/protocol"
 	"github.com/tinfoilsh/tfshim/key"
+	"github.com/tinfoilsh/tfshim/key/online"
 	"github.com/tinfoilsh/verifier/attestation"
 )
 
@@ -204,7 +206,12 @@ func newMux(
 
 			if err := validator.Validate(apiKey); err != nil {
 				log.Warnf("Failed to validate API key: %v", err)
-				http.Error(w, "shim: 401 invalid API key", http.StatusUnauthorized)
+				var validationErr *online.ValidationError
+				if errors.As(err, &validationErr) {
+					http.Error(w, validationErr.Message, validationErr.StatusCode)
+				} else {
+					http.Error(w, "shim: 500 validation error", http.StatusInternalServerError)
+				}
 				return
 			}
 		}

--- a/key/online/verify.go
+++ b/key/online/verify.go
@@ -17,12 +17,23 @@ func NewValidator(server string) (*Validator, error) {
 	}, nil
 }
 
+type ValidationError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *ValidationError) Error() string {
+	return e.Message
+}
+
 func (v *Validator) Validate(apiKey string) error {
 	resp, err := http.Post(v.server, "application/json", bytes.NewBufferString(apiKey))
 	if err != nil {
-		return err
+		return fmt.Errorf("validation request failed: %w", err)
 	}
-	if resp.StatusCode == 200 {
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
 		return nil
 	}
 
@@ -31,5 +42,8 @@ func (v *Validator) Validate(apiKey string) error {
 		return fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	return fmt.Errorf("failed to validate key: %s", string(body))
+	return &ValidationError{
+		StatusCode: resp.StatusCode,
+		Message:    string(body),
+	}
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Passes through control plane API key validation errors so clients receive the original status code and message instead of a generic 401. This improves debugging and aligns responses with the control plane.

- **New Features**
  - Return control plane status code and message on validation failure via a new ValidationError type.
  - Fallback to 500 with "validation error" for non-validation failures.
  - Close response bodies and wrap request errors with context.

<!-- End of auto-generated description by cubic. -->

